### PR TITLE
Improve compatibility of scope-names and support indentation adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # language-tamarin package
 
-Support for the Tamarin theorem prover
+Support for the [Tamarin theorem prover](https://tamarin-prover.github.io/manual/book/001_introduction.html).

--- a/grammars/tamarin.cson
+++ b/grammars/tamarin.cson
@@ -1,4 +1,4 @@
-'scopeName': 'source.spthy'
+'scopeName': 'source.tamarin'
 'name': 'Tamarin'
 'fileTypes': ['spthy']
 
@@ -8,35 +8,37 @@
 'patterns': [
 	{
 		'begin': '//'
-		'end': '\\n'
-		'name': 'comment.line'
+		'end': '$'
+		'name': 'comment.line.double-slash.tamarin'
+		'beginCaptures':
+			'0': 'name': 'punctuation.definition.comment.tamarin'
 	}
 	{
 		'match': '\\b(theory|builtins|functions|equations)\\b'
-		'name': 'keyword.control.structure'
+		'name': 'keyword.control.structure.tamarin'
 	}
 	{
 		'match': '\\b(rule|lemma|axiom|begin|end|let|in|All|Ex)\\b'
-		'name': 'keyword.control'
+		'name': 'keyword.control.tamarin'
 	}
 	{
 		'match': '(!|--\\[|\\]->|-->|\\[|\\]|=|:|/|\\(|\\)|"|,|\\.|==>|<|@)'
-		'name': 'keyword.operator'
+		'name': 'keyword.operator.tamarin'
 	}
 	{
 		'match': '(\\~|\\$|#)'
-		'name': 'keyword.other'
+		'name': 'keyword.other.tamarin'
 	}
-  {
-    'match': '\\b[a-zA-Z0-9_]+(?=([(]|/))\\b'
-    'name': 'entity.name.function.declaration.aif'
-  }
-  {
-    'match': '\\b[a-zA-Z0-9_]+\\b'
-    'name': 'variable.other.aif'
-  }
+	{
+		'match': '\\b[a-zA-Z0-9_]+(?=([(]|/))\\b'
+		'name': 'entity.name.function.declaration.tamarin'
+	}
+	{
+		'match': '\\b[a-zA-Z0-9_]+\\b'
+		'name': 'variable.other.tamarin'
+	}
 	{
 		'match': '\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((E|e)(\\+|-)?[0-9]+)?\\b'
-		'name': 'constant.numeric'
+		'name': 'constant.numeric.tamarin'
 	}
 ]

--- a/grammars/tamarin.cson
+++ b/grammars/tamarin.cson
@@ -18,7 +18,15 @@
 		'name': 'keyword.control.structure.tamarin'
 	}
 	{
-		'match': '\\b(rule|lemma|axiom|begin|end|let|in|All|Ex)\\b'
+		'match': '\\b(rule|lemma)(?:\\s+([^\\s:]+)\\s*(:)?|\\b)'
+		'name': 'meta.$1.tamarin'
+		'captures':
+			'1': 'name': 'storage.type.$1.tamarin'
+			'2': 'name': 'entity.name.function.tamarin'
+			'3': 'name': 'punctuation.separator.key-value.tamarin'
+	}
+	{
+		'match': '\\b(axiom|begin|end|let|in|All|Ex)\\b'
 		'name': 'keyword.control.tamarin'
 	}
 	{

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "language-tamarin",
-  "main": "./lib/language-tamarin",
   "version": "0.1.0",
   "description": "Support for the Tamarin theorem prover",
-  "keywords": [],
+  "keywords": ["spthy", "theorem", "protocol", "TLS"],
   "repository": "https://github.com/hoheinzollern/language-tamarin",
   "license": "MIT",
   "engines": {

--- a/settings/language-tamarin.cson
+++ b/settings/language-tamarin.cson
@@ -1,3 +1,3 @@
-'.source.spthy':
+'.source.tamarin':
   'editor':
     'commentStart': '// '

--- a/settings/language-tamarin.cson
+++ b/settings/language-tamarin.cson
@@ -1,3 +1,4 @@
 '.source.tamarin':
-  'editor':
-    'commentStart': '// '
+	'editor':
+		'commentStart': '// '
+		'increaseIndentPattern': '\\b(rule|lemma)\\s.*:\\s*$'


### PR DESCRIPTION
Hey there,

I've cleaned a few things up for you: namely the choice of [scope-names](http://manual.macromates.com/en/language_grammars#naming_conventions) which will improve highlighting between different syntax themes. I also added support for increasing editor indentation after lines containing `rule` or `lemma` declarations:

~~~coffee
rule name:
	…

lemma name:
	…
~~~

I actually don't know this language at all, so I haven't added any new patterns. However, there appear to be some missing operators/keywords, going by the [official repository's syntax files](https://github.com/tamarin-prover/tamarin-prover/tree/develop/etc).